### PR TITLE
fix: Run iosAddTarget after add

### DIFF
--- a/plugin.xml
+++ b/plugin.xml
@@ -92,7 +92,7 @@ SOFTWARE.
     <!-- Cordova hooks -->
     <hook type="before_plugin_install" src="hooks/npmInstall.js" />
     <hook type="before_plugin_install" src="hooks/iosCopyShareExtension.js" />
-    <hook type="after_plugin_install" src="hooks/iosAddTarget.js" />
+    <hook type="after_plugin_add" src="hooks/iosAddTarget.js" />
     <hook type="after_prepare" src="hooks/iosCopyShareExtension.js" />
 
     <!-- Dependencies -->


### PR DESCRIPTION
and not just install. Like that we can remove / add platform and the plugin is still there